### PR TITLE
Fix deleted blogs

### DIFF
--- a/widgy_blog/models.py
+++ b/widgy_blog/models.py
@@ -95,7 +95,9 @@ class BlogLayout(DefaultLayout):
             # put this query in widgy
             VersionTracker = site.get_version_tracker_model()
             published_commit_ids = VersionTracker.objects.published().annotate(
-                max_commit_id=Max('commits__pk')
+                max_commit_id=Max('commits__pk'),
+            ).filter(
+                pk__in=Blog.objects.all().values('content'),
             ).values('max_commit_id')
 
             # After https://code.djangoproject.com/ticket/20378


### PR DESCRIPTION
Maya found this bug:

> - Added a test news item
> - Deleted the news item in the admin center
> - News item is still being displayed on the front end

Here's my fix. I would like you @gavinwahl to review that since you're main author of those queries.

Thanks
