### PR TITLE
Month archive view should filter by year also

### DIFF
--- a/widgy_blog/views.py
+++ b/widgy_blog/views.py
@@ -143,7 +143,7 @@ class BlogYearArchiveView(BlogListView):
         return kwargs
 
 
-class BlogMonthArchiveView(BlogListView):
+class BlogMonthArchiveView(BlogYearArchiveView):
     def get_queryset(self):
         qs = super(BlogMonthArchiveView, self).get_queryset()
         return qs.filter(date__month=self.kwargs['month'])


### PR DESCRIPTION
Currently, the month archive view displays all articles published in the same month, regardless of year. We only want to display articles that were published in a specific month in a specific year. 
