### PR TITLE
AbstractBlogLayout subclasses override too much

### DIFF
--- a/widgy_blog/admin.py
+++ b/widgy_blog/admin.py
@@ -76,7 +76,7 @@ class BlogChangeList(ChangeList):
 
 class BlogAdmin(WidgyAdmin):
     form = BlogForm
-
+    layout_model = BlogLayout
     # These are the fields that are actually stored in widgy, not the
     # owner. We copy them back and forth to make the editing interface
     # nicer.
@@ -122,7 +122,7 @@ class BlogAdmin(WidgyAdmin):
             'fields': self.layout_proxy_fields,
         }
         defaults.update(kwargs)
-        LayoutModelForm = modelform_factory(BlogLayout, **defaults)
+        LayoutModelForm = modelform_factory(self.layout_model, **defaults)
         LayoutForm = type('BlogLayoutForm', (BlogForm,), LayoutModelForm.base_fields)
         LayoutForm.layout_proxy_fields = self.layout_proxy_fields
 


### PR DESCRIPTION
AbstractBlogLayout forced subclasses to override the Queryset
class and the owner property in order to specify different owner
models. Now, subclasses can just override the owner_class.

This PR also refactors the code of the Queryset class based on the
fix that was implemented in Django with this ticket:
https://code.djangoproject.com/ticket/20378
