### PR TITLE
Make blog lists generate canonical urls

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,9 @@ CHANGES
 0.2.0 (not yet released)
 ------------------------
 
+- Blog views with a page querystring equal to 1 will now have a canonical_url
+  in the template context pointing to the same page without that querystring.
+
 0.1.0 (release 2014-12-03)
 --------------------------
 


### PR DESCRIPTION
A blog list view with query page=1 should be the same view as
a blog list with no query. Have the view generate a canonical url
from the request path when page=1.